### PR TITLE
Enable Legends

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,7 @@ const chart = new Chart(document.getElementById("chart") as HTMLCanvasElement, {
     animation: false,
     plugins: {
       legend: {
-        display: false,
+        display: true,
       },
     },
     responsive: true,


### PR DESCRIPTION
The weapon selection list is too long, and in many cases you can't see the whole thing. I find my self scrolling a lot to reference which lines are which.

Having the legends completely alleviates this, and also makes it easier to share images

![image](https://user-images.githubusercontent.com/2672832/167438136-b1d614f5-154b-4c1c-9497-709d02a70caa.png)
