### PR TITLE
Allow users to select averaged target damage output

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,12 @@
         <fieldset id="target">
           <legend>Target</legend>
           <div>
+            <input type="radio" name="target" id="Average" /><label
+              for="Average"
+              >Average</label
+            ><br />
+          </div>
+          <div>
             <input type="radio" name="target" id="Vanguard / Archer" /><label
               for="Vanguard / Archer"
               >Vanguard / Archer</label

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ Chart.register(...registerables); // the auto import stuff was making typescript
 const STATS: WeaponStats = generateMetrics(ALL_WEAPONS);
 const UNIT_STATS: UnitStats = unitGroupStats(STATS);
 
-let selectedTarget = Target.VANGUARD_ARCHER;
+let selectedTarget = Target.AVERAGE;
 const selectedWeapons = new Set<Weapon>();
 const selectedCategories = new Set<MetricLabel>();
 

--- a/src/target.ts
+++ b/src/target.ts
@@ -2,4 +2,5 @@ export enum Target {
   VANGUARD_ARCHER = "Vanguard / Archer",
   FOOTMAN = "Footman",
   KNIGHT = "Knight",
+  AVERAGE = "Average"
 }

--- a/src/weapon.ts
+++ b/src/weapon.ts
@@ -1,6 +1,11 @@
 import { Target } from "./target";
 
 export function bonusMult(target: Target, type: DamageType): number {
+  if (target === Target.AVERAGE) {
+    let sum = bonusMult(Target.VANGUARD_ARCHER, type) + bonusMult(Target.FOOTMAN, type) + bonusMult(Target.KNIGHT, type)
+    return sum/3;
+  }
+
   if (target === Target.VANGUARD_ARCHER) {
     return 1;
   }


### PR DESCRIPTION
So people can see how weapons will behave on average, given that a weapon will be used on all enemy types at rather unpredictable times.